### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
   ],
   "require": {
     "php": ">=5.5",
-    "illuminate/config": "~5.1|~5.2",
-    "illuminate/database": "~5.1|~5.2",
-    "illuminate/support": "~5.1|~5.2",
+    "illuminate/config": "5.1.* || 5.2.*",
+    "illuminate/database": "5.1.* || 5.2.*",
+    "illuminate/support": "5.1.* || 5.2.*",
     "scrutinizer/ocular": "^1.3"
   },
   "require-dev": {


### PR DESCRIPTION
`~5.1` and `~5.2` is actually the same constraint. `~5.1` will cover `5.2` as well.

Since Laravel [doesn't follow semantic versioning](https://medium.com/@vinkla/laravel-packages-and-semantic-versioning-f62dc5accee5) we wont know if this package will break in version 5.3. The solution is to be more specific with the version constraint.