### PR TITLE
Support of table prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 /vendor/
 composer.lock
 composer.phar
+# workspace files are user-specific
+*.sublime-workspace
+*.sublime-project
+.idea
+.vscode

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -101,7 +101,7 @@ class Tag extends Model
      */
     protected function taggedModels(string $class): MorphToMany
     {
-        return $this->morphedByMany($class, 'taggable', 'taggable_taggables', 'tag_id');
+        return $this->morphedByMany($class, 'taggable', env('DB_TABLE_PREFIX', '').'taggable_taggables', 'tag_id');
     }
 
     /**

--- a/src/Services/TagService.php
+++ b/src/Services/TagService.php
@@ -194,7 +194,7 @@ class TagService
             $class = get_class($class);
         }
 
-        $sql = 'SELECT DISTINCT t.* FROM taggable_taggables tt LEFT JOIN taggable_tags t ON tt.tag_id=t.tag_id' .
+        $sql = 'SELECT DISTINCT t.* FROM '.env('DB_TABLE_PREFIX', '').'taggable_taggables tt LEFT JOIN '.env('DB_TABLE_PREFIX', '').'taggable_tags t ON tt.tag_id=t.tag_id' .
             ' WHERE tt.taggable_type = ?';
 
         return $this->tagModel::fromQuery($sql, [$class]);
@@ -235,7 +235,7 @@ class TagService
      */
     public function getAllUnusedTags(): Collection
     {
-        $sql = 'SELECT t.* FROM taggable_tags t LEFT JOIN taggable_taggables tt ON tt.tag_id=t.tag_id ' .
+        $sql = 'SELECT t.* FROM '.env('DB_TABLE_PREFIX', '').'taggable_tags t LEFT JOIN '.env('DB_TABLE_PREFIX', '').'taggable_taggables tt ON tt.tag_id=t.tag_id ' .
             'WHERE tt.taggable_id IS NULL';
 
         return $this->tagModel::fromQuery($sql);
@@ -252,7 +252,7 @@ class TagService
      */
     public function getPopularTags(int $limit = null, $class = null, int $minCount = 1): Collection
     {
-        $sql = 'SELECT t.*, COUNT(t.tag_id) AS taggable_count FROM taggable_tags t LEFT JOIN taggable_taggables tt ON tt.tag_id=t.tag_id';
+        $sql = 'SELECT t.*, COUNT(t.tag_id) AS taggable_count FROM '.env('DB_TABLE_PREFIX', '').'taggable_tags t LEFT JOIN '.env('DB_TABLE_PREFIX', '').'taggable_taggables tt ON tt.tag_id=t.tag_id';
         $bindings = [];
 
         if ($class) {

--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -38,7 +38,7 @@ trait Taggable
     public function tags(): MorphToMany
     {
         $model = config('taggable.model');
-        return $this->morphToMany($model, 'taggable', 'taggable_taggables', 'taggable_id', 'tag_id')
+        return $this->morphToMany($model, 'taggable', env('DB_TABLE_PREFIX', '').'taggable_taggables', 'taggable_id', 'tag_id')
             ->withTimestamps();
     }
 


### PR DESCRIPTION
Hello.

The migration script does care of the table prefix, so tables are well created using the prefix, but next, in eloquent-taggable the tables names are hardcoded in the queries, so it leads to some "table not found" exceptions.

So I added support of table prefix through the env('DB_TABLE_PREFIX').
There is maybe a better way to do it, but this one "just works".

Hope it can help.
Cédric.

