### PR TITLE
Combining scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,26 @@ Model::withAnyTags('');
 Model::withAllTags('Apple,Fig');
 ```
 
+Combining scopes:
+
+```php
+// Find models with any one of the given tags
+// i.e. everything tagged "Apple OR Banana".
+// but without one of the given tags 
+// i.e. everything NOT tagged "Cherry".
+// (returns Ids: 2, 3, 6, 7, 8)
+
+Model::withAnyTags('Apple,Banana')::withoutAnyTags('Cherry')->get();
+
+// Find models that are not tagged with all of the given tags,
+// i.e. everything not tagged "Apple AND Banana".
+// and models without any one of the given tags
+// i.e. everything not tagged "Cherry OR Durian".
+// (returns models with Ids: 2)
+
+Model::withoutAllTags('Apple,Banana')::withoutAnyTags('Cherry,Durian')->get();
+```
+
 Finally, you can easily find all the tags used across all instances of a model:
 
 ```php

--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -245,7 +245,7 @@ trait Taggable
         $alias = strtolower(__FUNCTION__);
         $morphTagKeyName = $this->getQualifiedRelatedPivotKeyNameWithAlias($alias);
 
-        return $this->prepareTableJoin($query, 'inner',$alias)
+        return $this->prepareTableJoin($query, 'inner', $alias)
             ->whereIn($morphTagKeyName, $tagKeys);
     }
 
@@ -259,7 +259,7 @@ trait Taggable
     public function scopeIsTagged(Builder $query): Builder
     {
         $alias = strtolower(__FUNCTION__);
-        return $this->prepareTableJoin($query, 'inner',$alias);
+        return $this->prepareTableJoin($query, 'inner', $alias);
     }
 
     /**
@@ -283,7 +283,7 @@ trait Taggable
         $alias = strtolower(__FUNCTION__);
         $morphTagKeyName = $this->getQualifiedRelatedPivotKeyNameWithAlias($alias);
 
-        $query = $this->prepareTableJoin($query, 'left',$alias)
+        $query = $this->prepareTableJoin($query, 'left', $alias)
             ->havingRaw("COUNT(DISTINCT CASE WHEN ({$morphTagKeyName} IN ({$tagKeyList})) THEN {$morphTagKeyName} ELSE NULL END) < ?",
                 [count($tagKeys)]);
 
@@ -315,7 +315,7 @@ trait Taggable
         $alias = strtolower(__FUNCTION__);
         $morphTagKeyName = $this->getQualifiedRelatedPivotKeyNameWithAlias($alias);
 
-        $query = $this->prepareTableJoin($query, 'left',$alias)
+        $query = $this->prepareTableJoin($query, 'left', $alias)
             ->havingRaw("COUNT(DISTINCT CASE WHEN ({$morphTagKeyName} IN ({$tagKeyList})) THEN {$morphTagKeyName} ELSE NULL END) = 0");
 
         if (!$includeUntagged) {
@@ -337,7 +337,7 @@ trait Taggable
         $alias = strtolower(__FUNCTION__);
         $morphForeignKeyName = $this->getQualifiedForeignPivotKeyNameWithAlias($alias);
 
-        return $this->prepareTableJoin($query, 'left',$alias)
+        return $this->prepareTableJoin($query, 'left', $alias)
             ->havingRaw("COUNT(DISTINCT {$morphForeignKeyName}) = 0");
     }
 
@@ -448,8 +448,8 @@ trait Taggable
     }
 
     /**
-     * Returns the Related Pivot Key Name with the table alias
-     * 
+     * Returns the Related Pivot Key Name with the table alias.
+     *
      * @param $alias
      *
      * @return string
@@ -461,7 +461,7 @@ trait Taggable
     }
 
     /**
-     * Returns the Foreign Pivot Key Name with the table alias
+     * Returns the Foreign Pivot Key Name with the table alias.
      *
      * @param $alias
      *

--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -206,9 +206,10 @@ trait Taggable
             return $query->where(\DB::raw(1), 0);
         }
 
-        $morphTagKeyName = $this->tags()->getQualifiedRelatedPivotKeyName();
+        $alias = strtolower(__FUNCTION__);
+        $morphTagKeyName = $this->getQualifiedRelatedPivotKeyNameWithAlias($alias);
 
-        return $this->prepareTableJoin($query, 'inner')
+        return $this->prepareTableJoin($query, 'inner', $alias)
             ->whereIn($morphTagKeyName, $tagKeys)
             ->havingRaw("COUNT({$morphTagKeyName}) = ?", [count($tagKeys)]);
     }
@@ -241,9 +242,10 @@ trait Taggable
 
         $tagKeys = $service->getTagModelKeys($normalized);
 
-        $morphTagKeyName = $this->tags()->getQualifiedRelatedPivotKeyName();
+        $alias = strtolower(__FUNCTION__);
+        $morphTagKeyName = $this->getQualifiedRelatedPivotKeyNameWithAlias($alias);
 
-        return $this->prepareTableJoin($query, 'inner')
+        return $this->prepareTableJoin($query, 'inner',$alias)
             ->whereIn($morphTagKeyName, $tagKeys);
     }
 
@@ -256,7 +258,8 @@ trait Taggable
      */
     public function scopeIsTagged(Builder $query): Builder
     {
-        return $this->prepareTableJoin($query, 'inner');
+        $alias = strtolower(__FUNCTION__);
+        return $this->prepareTableJoin($query, 'inner',$alias);
     }
 
     /**
@@ -277,9 +280,10 @@ trait Taggable
         $tagKeys = $service->getTagModelKeys($normalized);
         $tagKeyList = implode(',', $tagKeys);
 
-        $morphTagKeyName = $this->tags()->getQualifiedRelatedPivotKeyName();
+        $alias = strtolower(__FUNCTION__);
+        $morphTagKeyName = $this->getQualifiedRelatedPivotKeyNameWithAlias($alias);
 
-        $query = $this->prepareTableJoin($query, 'left')
+        $query = $this->prepareTableJoin($query, 'left',$alias)
             ->havingRaw("COUNT(DISTINCT CASE WHEN ({$morphTagKeyName} IN ({$tagKeyList})) THEN {$morphTagKeyName} ELSE NULL END) < ?",
                 [count($tagKeys)]);
 
@@ -308,9 +312,10 @@ trait Taggable
         $tagKeys = $service->getTagModelKeys($normalized);
         $tagKeyList = implode(',', $tagKeys);
 
-        $morphTagKeyName = $this->tags()->getQualifiedRelatedPivotKeyName();
+        $alias = strtolower(__FUNCTION__);
+        $morphTagKeyName = $this->getQualifiedRelatedPivotKeyNameWithAlias($alias);
 
-        $query = $this->prepareTableJoin($query, 'left')
+        $query = $this->prepareTableJoin($query, 'left',$alias)
             ->havingRaw("COUNT(DISTINCT CASE WHEN ({$morphTagKeyName} IN ({$tagKeyList})) THEN {$morphTagKeyName} ELSE NULL END) = 0");
 
         if (!$includeUntagged) {
@@ -329,9 +334,10 @@ trait Taggable
      */
     public function scopeIsNotTagged(Builder $query): Builder
     {
-        $morphForeignKeyName = $this->tags()->getQualifiedForeignPivotKeyName();
+        $alias = strtolower(__FUNCTION__);
+        $morphForeignKeyName = $this->getQualifiedForeignPivotKeyNameWithAlias($alias);
 
-        return $this->prepareTableJoin($query, 'left')
+        return $this->prepareTableJoin($query, 'left',$alias)
             ->havingRaw("COUNT(DISTINCT {$morphForeignKeyName}) = 0");
     }
 
@@ -341,12 +347,15 @@ trait Taggable
      *
      * @return Builder
      */
-    private function prepareTableJoin(Builder $query, string $joinType): Builder
+    private function prepareTableJoin(Builder $query, string $joinType, string $alias): Builder
     {
-        $modelKeyName = $this->getQualifiedKeyName();
         $morphTable = $this->tags()->getTable();
-        $morphForeignKeyName = $this->tags()->getQualifiedForeignPivotKeyName();
-        $morphTypeName = $morphTable . '.' . $this->tags()->getMorphType();
+        $morphTableAlias = $morphTable.'_'.$alias;
+
+        $modelKeyName = $this->getQualifiedKeyName();
+        $morphForeignKeyName = $this->getQualifiedForeignPivotKeyNameWithAlias($alias);
+
+        $morphTypeName = $morphTableAlias.'.'. $this->tags()->getMorphType();
         $morphClass = $this->tags()->getMorphClass();
 
         $closure = function(JoinClause $join) use ($modelKeyName, $morphForeignKeyName, $morphTypeName, $morphClass) {
@@ -356,7 +365,7 @@ trait Taggable
 
         return $query
             ->select($this->getTable() . '.*')
-            ->join($morphTable, $closure, null, null, $joinType)
+            ->join($morphTable.' as '.$morphTableAlias, $closure, null, null, $joinType)
             ->groupBy($modelKeyName);
     }
 
@@ -437,4 +446,31 @@ trait Taggable
 
         return $tags->pluck('taggable_count', 'normalized')->all();
     }
+
+    /**
+     * Returns the Related Pivot Key Name with the table alias
+     * 
+     * @param $alias
+     *
+     * @return string
+     */
+    private function getQualifiedRelatedPivotKeyNameWithAlias($alias){
+        $field = $this->tags()->getRelatedPivotKeyName();
+        $table = $this->tags()->getTable().'_'.$alias;
+        return $table.'.'.$field;
+    }
+
+    /**
+     * Returns the Foreign Pivot Key Name with the table alias
+     *
+     * @param $alias
+     *
+     * @return string
+     */
+    private function getQualifiedForeignPivotKeyNameWithAlias($alias){
+        $field = $this->tags()->getForeignPivotKeyName();
+        $table = $this->tags()->getTable().'_'.$alias;
+        return $table.'.'.$field;
+    }
+
 }

--- a/tests/ScopeTests.php
+++ b/tests/ScopeTests.php
@@ -300,4 +300,43 @@ class ScopeTests extends TestCase
             $keys
         );
     }
+
+    /**
+     * Test searching by any tags and without any tags.
+     */
+    public function testWithAnyTagsAndWithoutAnyTags()
+    {
+        /** @var Collection $models */
+        $models = TestModel::withAnyTags('Apple,Banana')->withoutAnyTags('Cherry')->get();
+        $keys = $models->modelKeys();
+
+        $this->assertArrayValuesAreEqual(
+            [
+                $this->testModel2->getKey(),
+                $this->testModel3->getKey(),
+                $this->testModel6->getKey(),
+                $this->testModel7->getKey(),
+                $this->testModel8->getKey(),
+            ],
+            $keys
+        );
+    }
+
+
+    /**
+     * Test searching without all tags and without any tags.
+     */
+    public function testWithoutAllTagsAndWithoutAnyTags()
+    {
+        /** @var Collection $models */
+        $models = TestModel::withoutAllTags('Apple,Banana')->withoutAnyTags('Cherry,Durian')->get();
+        $keys = $models->modelKeys();
+
+        $this->assertArrayValuesAreEqual(
+            [
+                $this->testModel2->getKey()
+            ],
+            $keys
+        );
+    }
 }


### PR DESCRIPTION
Combining scopes to create complex queries.

Now we can use two or more scopes in the same command. As described on Readme.md you can do this:
`Model::withAnyTags('Apple,Banana')::withoutAnyTags('Cherry')->get();`

For each scope Im using the command __FUNCTION__ to create a unique alias. So we can combine how many scopes we want without ambiguous tables/columns error.



Thank you for helping to make this package better!

Please make sure you've read [CONTRIBUTING.md](https://github.com/cviebrock/eloquent-sluggable/blob/master/CONTRIBUTING.md) 
before submitting your pull request, and that you have:

- [x] provided a rationale for your change (I try not to add features that are going to have a limited user-base)
- [x] used the [PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- [x] added tests
- [x] documented any change in behaviour (e.g. updated the `README.md`, etc.)
- [x] only submitted one pull request per feature

**Thank you!**
