### PR TITLE
Create a new alias to use on scopes to be able to combine many scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,13 @@ Model::withAnyTags('Apple,Banana')::withoutAnyTags('Cherry')->get();
 // (returns models with Ids: 2)
 
 Model::withoutAllTags('Apple,Banana')::withoutAnyTags('Cherry,Durian')->get();
+
+// Find models with any one of the given tags
+// i.e. everything tagged "Apple OR Banana".
+// AND tagged "Cherry OR Durian".
+// (returns Ids: 4, 6, 7, 8)
+
+Model::withAnyTags('Apple,Banana')::withAnyTags('Cherry,Durian')->get();
 ```
 
 Finally, you can easily find all the tags used across all instances of a model:

--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -223,7 +223,7 @@ trait Taggable
 
         return $this->prepareTableJoin($query, 'inner', $alias)
             ->whereIn($morphTagKeyName, $tagKeys)
-            ->havingRaw("COUNT({$morphTagKeyName}) = ?", [count($tagKeys)]);
+            ->havingRaw("COUNT(DISTINCT {$morphTagKeyName}) = ?", [count($tagKeys)]);
     }
 
     /**

--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -17,6 +17,12 @@ use Illuminate\Database\Query\JoinClause;
  */
 trait Taggable
 {
+    /**
+     * Property to control sequence on alias
+     *
+     * @var int
+     */
+    private $taggableAliasSequence = 0;
 
     /**
      * Boot the trait.
@@ -212,7 +218,7 @@ trait Taggable
             return $query->where(\DB::raw(1), 0);
         }
 
-        $alias = strtolower(__FUNCTION__);
+        $alias = $this->taggableCreateNewAlias(__FUNCTION__);
         $morphTagKeyName = $this->getQualifiedRelatedPivotKeyNameWithAlias($alias);
 
         return $this->prepareTableJoin($query, 'inner', $alias)
@@ -248,7 +254,7 @@ trait Taggable
 
         $tagKeys = $service->getTagModelKeys($normalized);
 
-        $alias = strtolower(__FUNCTION__);
+        $alias = $this->taggableCreateNewAlias(__FUNCTION__);
         $morphTagKeyName = $this->getQualifiedRelatedPivotKeyNameWithAlias($alias);
 
         return $this->prepareTableJoin($query, 'inner', $alias)
@@ -264,7 +270,7 @@ trait Taggable
      */
     public function scopeIsTagged(Builder $query): Builder
     {
-        $alias = strtolower(__FUNCTION__);
+        $alias = $this->taggableCreateNewAlias(__FUNCTION__);
         return $this->prepareTableJoin($query, 'inner', $alias);
     }
 
@@ -286,7 +292,7 @@ trait Taggable
         $tagKeys = $service->getTagModelKeys($normalized);
         $tagKeyList = implode(',', $tagKeys);
 
-        $alias = strtolower(__FUNCTION__);
+        $alias = $this->taggableCreateNewAlias(__FUNCTION__);
         $morphTagKeyName = $this->getQualifiedRelatedPivotKeyNameWithAlias($alias);
 
         $query = $this->prepareTableJoin($query, 'left', $alias)
@@ -318,7 +324,7 @@ trait Taggable
         $tagKeys = $service->getTagModelKeys($normalized);
         $tagKeyList = implode(',', $tagKeys);
 
-        $alias = strtolower(__FUNCTION__);
+        $alias = $this->taggableCreateNewAlias(__FUNCTION__);
         $morphTagKeyName = $this->getQualifiedRelatedPivotKeyNameWithAlias($alias);
 
         $query = $this->prepareTableJoin($query, 'left', $alias)
@@ -340,7 +346,7 @@ trait Taggable
      */
     public function scopeIsNotTagged(Builder $query): Builder
     {
-        $alias = strtolower(__FUNCTION__);
+        $alias = $this->taggableCreateNewAlias(__FUNCTION__);
         $morphForeignKeyName = $this->getQualifiedForeignPivotKeyNameWithAlias($alias);
 
         return $this->prepareTableJoin($query, 'left', $alias)
@@ -481,4 +487,18 @@ trait Taggable
         return $table.'.'.$field;
     }
 
+    /**
+     * Create a new alias to use on scopes to be able to combine many scopes
+     *
+     * @param string $scope
+     * 
+     * @return string
+     */
+    private function taggableCreateNewAlias(string $scope)
+    {
+        $this->taggableAliasSequence++;
+        $alias = strtolower($scope) . '_' . $this->taggableAliasSequence;
+
+        return $alias;
+    }
 }

--- a/tests/ScopeTests.php
+++ b/tests/ScopeTests.php
@@ -322,7 +322,6 @@ class ScopeTests extends TestCase
         );
     }
 
-
     /**
      * Test searching without all tags and without any tags.
      */
@@ -335,6 +334,26 @@ class ScopeTests extends TestCase
         $this->assertArrayValuesAreEqual(
             [
                 $this->testModel2->getKey()
+            ],
+            $keys
+        );
+    }
+
+    /**
+     * Test searching by any tags and and after by any tags again.
+     */
+    public function testWithAnyTagsAndWithAnyTagsAgain()
+    {
+        /** @var Collection $models */
+        $models = TestModel::withAnyTags('Apple,Banana')->withAnyTags('Cherry,Durian')->get();
+        $keys = $models->modelKeys();
+
+        $this->assertArrayValuesAreEqual(
+            [
+                $this->testModel4->getKey(), //Apple, Banana, Cherry
+                $this->testModel6->getKey(), //Apple, Durian
+                $this->testModel7->getKey(), //Banana, Durian
+                $this->testModel8->getKey(), //Apple, Banana, Durian
             ],
             $keys
         );


### PR DESCRIPTION
Create a new alias to use on scopes to be able to combine many scopes. This way we can use the same scope more than once. 

Like this:
```
// Find models with any one of the given tags
// i.e. everything tagged "Apple OR Banana".
// AND tagged "Cherry OR Durian".
// (returns Ids: 4, 6, 7, 8)

Model::withAnyTags('Apple,Banana')::withAnyTags('Cherry,Durian')->get();

//4 - Apple, Banana, Cherry
//6 - Apple, Durian
//7 - Banana, Durian
//8 - Apple, Banana, Durian
```
This is different than:
```
Model::withAnyTags('Apple,Banana,Cherry,Durian')->get();

//That returns this models:
//2 - Apple
//3 - Apple,Banana
//4 - Apple, Banana, Cherry
//5 - Cherry
//6 - Apple, Durian
//7 - Banana, Durian
//8 - Apple, Banana, Durian
```


Please make sure you've read [CONTRIBUTING.md](https://github.com/cviebrock/eloquent-sluggable/blob/master/CONTRIBUTING.md) 
before submitting your pull request, and that you have:

- [x] provided a rationale for your change (I try not to add features that are going to have a limited user-base)
- [x] used the [PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- [x] added tests
- [x] documented any change in behaviour (e.g. updated the `README.md`, etc.)
- [x] only submitted one pull request per feature

**Thank you!**
