### PR TITLE
Fixes #99

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,38 @@
 
 language: php
 
-php:
-  - 7.2
-  - 7.3
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.2
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
 
-env:
-  - COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
-  - COMPOSER_FLAGS=""
-
-before_script:
+before_install:
   - travis_retry composer self-update
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
-  - travis_retry composer dump-autoload
+  - travis_retry composer require --no-update --no-interaction "laravel/framework:${LARAVEL}" "orchestra/testbench:${TESTBENCH}"
+
+install:
+  - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction --no-suggest
 
 script:
   - php vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,38 +2,18 @@
 
 language: php
 
-matrix:
-  fast_finish: true
-  include:
-    - php: 7.2
-      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.2
-      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
-    - php: 7.2
-      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
-    - php: 7.2
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.2
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
-    - php: 7.3
-      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
-    - php: 7.3
-      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
-    - php: 7.3
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.3
-      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
-    - php: 7.3
-      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.3
-      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
+php:
+  - 7.2
+  - 7.3
 
-before_install:
+env:
+  - COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+  - COMPOSER_FLAGS=""
+
+before_script:
   - travis_retry composer self-update
-  - travis_retry composer require --no-update --no-interaction "laravel/framework:${LARAVEL}" "orchestra/testbench:${TESTBENCH}"
-
-install:
-  - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction --no-suggest
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+  - travis_retry composer dump-autoload
 
 script:
   - php vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ the _master_ branch by default, which might not be what you want).
     php artisan vendor:publish --provider="Cviebrock\EloquentTaggable\ServiceProvider"
     ```
 
-3. You can use custom migrations by changing the `custom_migrations` flag to `true` within the `config/taggable.php`
-file. You can add more fields, but can't remove the existing ones.
-
+3. You can publish this package migrations using the `vendor:publish` artisan command:
+```bash
+   php artisan vendor:publish --tag eloquent-taggable-migrations
+```
+> If you modify the provided migrations, keep in mind that you can add more fields, but can't remove the existing ones.
 
 4. Finally, use artisan to run the migration to create the required tables:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Easily add the ability to tag your Eloquent models in Laravel 6.
 * [Bugs, Suggestions, Contributions and Support](#bugs-suggestions-contributions-and-support)
 * [Copyright and License](#copyright-and-license)
 
-
 ---
 
 ## Installation
@@ -65,7 +64,11 @@ the _master_ branch by default, which might not be what you want).
     php artisan vendor:publish --provider="Cviebrock\EloquentTaggable\ServiceProvider"
     ```
 
-3. Finally, use artisan to run the migration to create the required tables:
+3. You can use custom migrations by changing the `custom_migrations` flag to `true` within the `config/taggable.php`
+file. You can add more fields, but can't remove the existing ones.
+
+
+4. Finally, use artisan to run the migration to create the required tables:
 
     ```sh
     composer dump-autoload

--- a/resources/config/taggable.php
+++ b/resources/config/taggable.php
@@ -60,4 +60,14 @@ return [
      * then update the configuration below.
      */
     'model'  => \Cviebrock\EloquentTaggable\Models\Tag::class,
+
+    /**
+     * The tables used to store the tags in the database. You can publish
+     * this migrations and use custom names if you want.
+     */
+    'tables' => [
+        'taggable_tags'      => 'taggable_tags',
+        'taggable_taggables' => 'taggable_taggables',
+        ''
+    ]
 ];

--- a/resources/config/taggable.php
+++ b/resources/config/taggable.php
@@ -68,6 +68,11 @@ return [
     'tables' => [
         'taggable_tags'      => 'taggable_tags',
         'taggable_taggables' => 'taggable_taggables',
-        ''
-    ]
+    ],
+
+    /**
+     * If you want to publish this package migrations and modify them, just change this
+     * flag to true and run php artisan vendor:publish --tag=eloquent-taggable-migrations
+     */
+    'custom_migrations' => false,
 ];

--- a/resources/config/taggable.php
+++ b/resources/config/taggable.php
@@ -68,11 +68,5 @@ return [
     'tables' => [
         'taggable_tags'      => 'taggable_tags',
         'taggable_taggables' => 'taggable_taggables',
-    ],
-
-    /**
-     * If you want to publish this package migrations and modify them, just change this
-     * flag to true and run php artisan vendor:publish --tag=eloquent-taggable-migrations
-     */
-    'custom_migrations' => false,
+    ]
 ];

--- a/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
+++ b/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
@@ -44,7 +44,8 @@ class CreateTaggableTable extends Migration
 
                 $table->foreign('tag_id')
                     ->references('tag_id')
-                    ->on($taggable_tags);
+                    ->on($taggable_tags)
+                    ->onDelete('cascade');
             });
         }
     }

--- a/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
+++ b/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
@@ -23,7 +23,7 @@ class CreateTaggableTable extends Migration
             Schema::connection($connection)->create($taggable_tags, function(Blueprint $table) {
                 $table->bigIncrements('tag_id');
                 $table->string('name');
-                $table->string('normalized');
+                $table->string('normalized')->unique();
                 $table->timestamps();
 
                 $table->index('normalized');

--- a/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
+++ b/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
@@ -30,7 +30,7 @@ class CreateTaggableTable extends Migration
             });
         }
 
-        $taggable_taggables = config('taggable.tables.taggable_taggables') ?? 'taggable_tags';
+        $taggable_taggables = config('taggable.tables.taggable_taggables') ?? 'taggable_taggables';
 
         if (!Schema::connection($connection)->hasTable($taggable_taggables)) {
             Schema::connection($connection)->create($taggable_taggables, function(Blueprint $table) use ($taggable_tags) {

--- a/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
+++ b/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
@@ -34,7 +34,7 @@ class CreateTaggableTable extends Migration
                 $table->unsignedBigInteger('taggable_id');
                 $table->string('taggable_type');
                 $table->timestamps();
-
+                $table->unique(['tag_id', 'taggable_id', 'taggable_type']);
                 $table->index(['tag_id', 'taggable_id'], 'i_taggable_fwd');
                 $table->index(['taggable_id', 'tag_id'], 'i_taggable_rev');
             });

--- a/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
+++ b/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
@@ -17,7 +17,7 @@ class CreateTaggableTable extends Migration
     {
         $connection = config('taggable.connection');
 
-        $taggable_tags = config('taggable.tables.taggable_tags') ?? 'taggable_tags';
+        $taggable_tags = config('taggable.tables.taggable_tags', 'taggable_tags');
 
         if (!Schema::connection($connection)->hasTable($taggable_tags)) {
             Schema::connection($connection)->create($taggable_tags, function(Blueprint $table) {
@@ -30,7 +30,7 @@ class CreateTaggableTable extends Migration
             });
         }
 
-        $taggable_taggables = config('taggable.tables.taggable_taggables') ?? 'taggable_taggables';
+        $taggable_taggables = config('taggable.tables.taggable_taggables', 'taggable_taggables');
 
         if (!Schema::connection($connection)->hasTable($taggable_taggables)) {
             Schema::connection($connection)->create($taggable_taggables, function(Blueprint $table) use ($taggable_tags) {
@@ -58,8 +58,8 @@ class CreateTaggableTable extends Migration
     public function down()
     {
         $connection = config('taggable.connection');
-        $taggable_tags = config('taggable.tables.taggable_tags') ?? 'taggable_tags';
-        $taggable_taggables = config('taggable.tables.taggable_taggables') ?? 'taggable_taggables';
+        $taggable_tags = config('taggable.tables.taggable_tags', 'taggable_tags');
+        $taggable_taggables = config('taggable.tables.taggable_taggables', 'taggable_taggables');
 
         if (Schema::connection($connection)->hasTable($taggable_tags)) {
             Schema::connection($connection)->drop($taggable_tags);

--- a/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
+++ b/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
@@ -21,7 +21,7 @@ class CreateTaggableTable extends Migration
 
         if (!Schema::connection($connection)->hasTable($taggable_tags)) {
             Schema::connection($connection)->create($taggable_tags, function(Blueprint $table) {
-                $table->bigIncrements('tag_id');
+                $table->bigIncrements('id');
                 $table->string('name')->unique();
                 $table->string('normalized')->unique();
                 $table->timestamps();
@@ -43,7 +43,7 @@ class CreateTaggableTable extends Migration
                 $table->index(['taggable_id', 'tag_id'], 'i_taggable_rev');
 
                 $table->foreign('tag_id')
-                    ->references('tag_id')
+                    ->references('id')
                     ->on($taggable_tags)
                     ->onDelete('cascade');
             });

--- a/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
+++ b/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
@@ -19,7 +19,7 @@ class CreateTaggableTable extends Migration
 
         if (!Schema::connection($connection)->hasTable('taggable_tags')) {
             Schema::connection($connection)->create('taggable_tags', function(Blueprint $table) {
-                $table->increments('tag_id');
+                $table->bigIncrements('tag_id');
                 $table->string('name');
                 $table->string('normalized');
                 $table->timestamps();
@@ -30,8 +30,8 @@ class CreateTaggableTable extends Migration
 
         if (!Schema::connection($connection)->hasTable('taggable_taggables')) {
             Schema::connection($connection)->create('taggable_taggables', function(Blueprint $table) {
-                $table->unsignedInteger('tag_id');
-                $table->unsignedInteger('taggable_id');
+                $table->unsignedBigInteger('tag_id');
+                $table->unsignedBigInteger('taggable_id');
                 $table->string('taggable_type');
                 $table->timestamps();
 

--- a/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
+++ b/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
@@ -33,7 +33,7 @@ class CreateTaggableTable extends Migration
         $taggable_taggables = config('taggable.tables.taggable_taggables') ?? 'taggable_tags';
 
         if (!Schema::connection($connection)->hasTable($taggable_taggables)) {
-            Schema::connection($connection)->create($taggable_taggables, function(Blueprint $table) {
+            Schema::connection($connection)->create($taggable_taggables, function(Blueprint $table) use ($taggable_tags) {
                 $table->unsignedBigInteger('tag_id');
                 $table->unsignedBigInteger('taggable_id');
                 $table->string('taggable_type');
@@ -41,6 +41,10 @@ class CreateTaggableTable extends Migration
                 $table->unique(['tag_id', 'taggable_id', 'taggable_type']);
                 $table->index(['tag_id', 'taggable_id'], 'i_taggable_fwd');
                 $table->index(['taggable_id', 'tag_id'], 'i_taggable_rev');
+
+                $table->foreign('tag_id')
+                    ->references('tag_id')
+                    ->on($taggable_tags);
             });
         }
     }

--- a/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
+++ b/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
@@ -17,8 +17,10 @@ class CreateTaggableTable extends Migration
     {
         $connection = config('taggable.connection');
 
-        if (!Schema::connection($connection)->hasTable('taggable_tags')) {
-            Schema::connection($connection)->create('taggable_tags', function(Blueprint $table) {
+        $taggable_tags = config('taggable.tables.taggable_tags') ?? 'taggable_tags';
+
+        if (!Schema::connection($connection)->hasTable($taggable_tags)) {
+            Schema::connection($connection)->create($taggable_tags, function(Blueprint $table) {
                 $table->bigIncrements('tag_id');
                 $table->string('name');
                 $table->string('normalized');
@@ -28,8 +30,10 @@ class CreateTaggableTable extends Migration
             });
         }
 
-        if (!Schema::connection($connection)->hasTable('taggable_taggables')) {
-            Schema::connection($connection)->create('taggable_taggables', function(Blueprint $table) {
+        $taggable_taggables = config('taggable.tables.taggable_taggables') ?? 'taggable_tags';
+
+        if (!Schema::connection($connection)->hasTable($taggable_taggables)) {
+            Schema::connection($connection)->create($taggable_taggables, function(Blueprint $table) {
                 $table->unsignedBigInteger('tag_id');
                 $table->unsignedBigInteger('taggable_id');
                 $table->string('taggable_type');
@@ -49,13 +53,15 @@ class CreateTaggableTable extends Migration
     public function down()
     {
         $connection = config('taggable.connection');
+        $taggable_tags = config('taggable.tables.taggable_tags') ?? 'taggable_tags';
+        $taggable_taggables = config('taggable.tables.taggable_taggables') ?? 'taggable_tags';
 
-        if (Schema::connection($connection)->hasTable('taggable_tags')) {
-            Schema::connection($connection)->drop('taggable_tags');
+        if (Schema::connection($connection)->hasTable($taggable_tags)) {
+            Schema::connection($connection)->drop($taggable_tags);
         }
 
-        if (Schema::connection($connection)->hasTable('taggable_taggables')) {
-            Schema::connection($connection)->drop('taggable_taggables');
+        if (Schema::connection($connection)->hasTable($taggable_taggables)) {
+            Schema::connection($connection)->drop($taggable_taggables);
         }
     }
 }

--- a/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
+++ b/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
@@ -37,7 +37,6 @@ class CreateTaggableTable extends Migration
 
                 $table->index(['tag_id', 'taggable_id'], 'i_taggable_fwd');
                 $table->index(['taggable_id', 'tag_id'], 'i_taggable_rev');
-                $table->index('taggable_type', 'i_taggable_type');
             });
         }
     }

--- a/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
+++ b/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
@@ -22,7 +22,7 @@ class CreateTaggableTable extends Migration
         if (!Schema::connection($connection)->hasTable($taggable_tags)) {
             Schema::connection($connection)->create($taggable_tags, function(Blueprint $table) {
                 $table->bigIncrements('tag_id');
-                $table->string('name');
+                $table->string('name')->unique();
                 $table->string('normalized')->unique();
                 $table->timestamps();
 

--- a/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
+++ b/resources/database/migrations/0000_00_00_000000_create_taggable_table.php
@@ -59,7 +59,7 @@ class CreateTaggableTable extends Migration
     {
         $connection = config('taggable.connection');
         $taggable_tags = config('taggable.tables.taggable_tags') ?? 'taggable_tags';
-        $taggable_taggables = config('taggable.tables.taggable_taggables') ?? 'taggable_tags';
+        $taggable_taggables = config('taggable.tables.taggable_taggables') ?? 'taggable_taggables';
 
         if (Schema::connection($connection)->hasTable($taggable_tags)) {
             Schema::connection($connection)->drop($taggable_tags);

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -16,7 +16,7 @@ class Tag extends Model
     /**
      * @inheritdoc
      */
-    protected $table = 'taggable_tags';
+    protected $table;
 
     /**
      * @inheritdoc
@@ -39,6 +39,8 @@ class Tag extends Model
         if ($connection = config('taggable.connection')) {
             $this->setConnection($connection);
         }
+
+        $this->setTable(config('taggable.tables.taggables_tags'));
 
         parent::__construct($attributes);
     }

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -21,11 +21,6 @@ class Tag extends Model
     /**
      * @inheritdoc
      */
-    protected $primaryKey = 'tag_id';
-
-    /**
-     * @inheritdoc
-     */
     protected $fillable = [
         'name',
         'normalized',

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -40,7 +40,7 @@ class Tag extends Model
             $this->setConnection($connection);
         }
 
-        $this->setTable(config('taggable.tables.taggables_tags'));
+        $this->setTable(config('taggable.tables.taggable_tags'));
 
         parent::__construct($attributes);
     }

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -35,7 +35,7 @@ class Tag extends Model
             $this->setConnection($connection);
         }
 
-        $this->setTable(config('taggable.tables.taggable_tags'));
+        $this->setTable(config('taggable.tables.taggable_tags', 'taggable_tags'));
 
         parent::__construct($attributes);
     }
@@ -99,7 +99,8 @@ class Tag extends Model
      */
     protected function taggedModels(string $class): MorphToMany
     {
-        return $this->morphedByMany($class, 'taggable', 'taggable_taggables', 'tag_id');
+        $table = config('taggable.tables.taggable_taggables', 'taggable_taggables');
+        return $this->morphedByMany($class, 'taggable', $table, 'tag_id');
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -26,9 +26,19 @@ class ServiceProvider extends LaravelServiceProvider
             __DIR__ . '/../resources/config/taggable.php' => config_path('taggable.php'),
         ], 'config');
 
-        $this->loadMigrationsFrom(
-            __DIR__.'/../resources/database/migrations'
-        );
+        $this->publishes([
+            __DIR__.'/../resources/database/migrations',
+        ], 'eloquent-taggable-migrations');
+
+        $custom_migrations = config('taggable.custom_migrations') ?? false;
+        if ($custom_migrations) {
+            $this->loadMigrationsFrom(database_path('migrations'));
+        } else {
+            $this->loadMigrationsFrom(
+                __DIR__.'/../resources/database/migrations'
+            );
+        }
+
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -66,7 +66,7 @@ class ServiceProvider extends LaravelServiceProvider
 
         return Collection::make($this->app->databasePath().DIRECTORY_SEPARATOR.'migrations'.DIRECTORY_SEPARATOR)
             ->flatMap(function ($path) use ($filesystem) {
-               return $filesystem->glob($path.'*_create_taggable_table.php');
+                return $filesystem->glob($path.'*_create_taggable_table.php');
             })->push($this->app->databasePath()."/migrations/{$timestamp}_create_taggable_table.php")
             ->first();
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,6 +1,8 @@
 <?php namespace Cviebrock\EloquentTaggable;
 
 use Cviebrock\EloquentTaggable\Services\TagService;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 
 
@@ -20,24 +22,26 @@ class ServiceProvider extends LaravelServiceProvider
     /**
      * Bootstrap the application events.
      */
-    public function boot()
+    public function boot(Filesystem $filesystem)
     {
         $this->publishes([
             __DIR__ . '/../resources/config/taggable.php' => config_path('taggable.php'),
         ], 'config');
 
+
         $this->publishes([
-            __DIR__.'/../resources/database/migrations/' => database_path('migrations'),
+            __DIR__.'/../resources/database/migrations/0000_00_00_000000_create_taggable_table.php' => $this->getMigrationFileName($filesystem)
         ], 'eloquent-taggable-migrations');
 
-        if (config('taggable.custom_migrations', false)) {
+        $package_migration = glob($this->app->databasePath()."/migrations/*_create_taggable_table.php");
+
+        if (count($package_migration) > 0) {
             $this->loadMigrationsFrom(database_path('migrations'));
         } else {
             $this->loadMigrationsFrom(
                 __DIR__.'/../resources/database/migrations'
             );
         }
-
     }
 
     /**
@@ -50,5 +54,20 @@ class ServiceProvider extends LaravelServiceProvider
         $this->mergeConfigFrom(__DIR__ . '/../resources/config/taggable.php', 'taggable');
 
         $this->app->singleton(TagService::class);
+    }
+
+    /**
+     * @param Filesystem $filesystem
+     * @return mixed
+     */
+    private function getMigrationFileName(Filesystem $filesystem)
+    {
+        $timestamp = date('Y_m_d_His');
+
+        return Collection::make($this->app->databasePath().DIRECTORY_SEPARATOR.'migrations'.DIRECTORY_SEPARATOR)
+            ->flatMap(function ($path) use ($filesystem) {
+               return $filesystem->glob($path.'*_create_taggable_table.php');
+            })->push($this->app->databasePath()."/migrations/{$timestamp}_create_taggable_table.php")
+            ->first();
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -27,7 +27,7 @@ class ServiceProvider extends LaravelServiceProvider
         ], 'config');
 
         $this->publishes([
-            __DIR__.'/../resources/database/migrations',
+            __DIR__.'/../resources/database/migrations/' => database_path('migrations'),
         ], 'eloquent-taggable-migrations');
 
         $custom_migrations = config('taggable.custom_migrations') ?? false;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -30,8 +30,7 @@ class ServiceProvider extends LaravelServiceProvider
             __DIR__.'/../resources/database/migrations/' => database_path('migrations'),
         ], 'eloquent-taggable-migrations');
 
-        $custom_migrations = config('taggable.custom_migrations') ?? false;
-        if ($custom_migrations) {
+        if (config('taggable.custom_migrations', false)) {
             $this->loadMigrationsFrom(database_path('migrations'));
         } else {
             $this->loadMigrationsFrom(

--- a/src/Services/TagService.php
+++ b/src/Services/TagService.php
@@ -119,7 +119,7 @@ class TagService
         }
 
         return $this->tagModel::whereIn('normalized', $normalized)
-            ->pluck('tag_id')
+            ->pluck('id')
             ->toArray();
     }
 
@@ -200,7 +200,7 @@ class TagService
 
         $sql = "SELECT DISTINCT t.*
               FROM {$pivotTable} tt 
-              LEFT JOIN {$tagTable} t ON tt.tag_id=t.tag_id
+              LEFT JOIN {$tagTable} t ON tt.tag_id=t.id
               WHERE tt.taggable_type = ?";
 
         return $this->tagModel::fromQuery($sql, [$class]);
@@ -246,7 +246,7 @@ class TagService
 
         $sql = "SELECT t.*
             FROM {$tagTable} t
-            LEFT JOIN {$pivotTable} tt ON tt.tag_id=t.tag_id
+            LEFT JOIN {$pivotTable} tt ON tt.tag_id=t.id
             WHERE tt.taggable_id IS NULL";
 
         return $this->tagModel::fromQuery($sql);
@@ -266,9 +266,9 @@ class TagService
         $tagTable = $this->getQualifiedTagTableName();
         $pivotTable = $this->getQualifiedPivotTableName();
 
-        $sql = "SELECT t.*, COUNT(t.tag_id) AS taggable_count 
+        $sql = "SELECT t.*, COUNT(t.id) AS taggable_count 
             FROM {$tagTable} t 
-            LEFT JOIN {$pivotTable} tt ON tt.tag_id=t.tag_id";
+            LEFT JOIN {$pivotTable} tt ON tt.tag_id=t.id";
         $bindings = [];
 
         if ($class) {
@@ -277,7 +277,7 @@ class TagService
         }
 
         // group by everything to handle strict and non-strict mode in MySQL
-        $sql .= ' GROUP BY t.tag_id, t.name, t.normalized, t.created_at, t.updated_at';
+        $sql .= ' GROUP BY t.id, t.name, t.normalized, t.created_at, t.updated_at';
 
         if ($minCount > 1) {
             $sql .= ' HAVING taggable_count >= ?';

--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -47,14 +47,15 @@ trait Taggable
     public function tags(): MorphToMany
     {
         $model = config('taggable.model');
-        return $this->morphToMany($model, 'taggable', 'taggable_taggables', 'taggable_id', 'tag_id')
+        $taggable_taggables = config('taggable.tables.taggable_taggables');
+        return $this->morphToMany($model, 'taggable', $taggable_taggables, 'taggable_id', 'tag_id')
             ->withTimestamps();
     }
 
     /**
      * Attach one or multiple tags to the model.
      *
-     * @param string|array $tags
+     * @param string|array $tags'
      *
      * @return self
      */

--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -47,7 +47,7 @@ trait Taggable
     public function tags(): MorphToMany
     {
         $model = config('taggable.model');
-        $taggable_taggables = config('taggable.tables.taggable_taggables');
+        $taggable_taggables = config('taggable.tables.taggable_taggables', 'taggable_taggables');
         return $this->morphToMany($model, 'taggable', $taggable_taggables, 'taggable_id', 'tag_id')
             ->withTimestamps();
     }
@@ -55,7 +55,7 @@ trait Taggable
     /**
      * Attach one or multiple tags to the model.
      *
-     * @param string|array $tags'
+     * @param string|array $tags
      *
      * @return self
      */

--- a/tests/CustomMigrationTest.php
+++ b/tests/CustomMigrationTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Cviebrock\EloquentTaggable\Test;
+
+class CustomMigrationTest extends TestCase
+{
+    public function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+        $app['config']->set('taggable.tables.taggable_tags', 'test_taggable_tags');
+        $app['config']->set('taggable.tables.taggable_taggables', 'test_taggable_taggables');
+    }
+
+    public function test_it_can_get_the_correct_table_name()
+    {
+        self::assertEquals('test_taggable_tags', config('taggable.tables.taggable_tags'));
+        self::assertEquals('test_taggable_taggables', config('taggable.tables.taggable_taggables'));
+    }
+
+}


### PR DESCRIPTION
This is related to #99:
- [x] Use big integers for all keys.
- [x] Remove index in `taggable_taggables.taggable_type`
- [x] Add a unique constraint to the `taggable_taggables`, for the `tag_id`, `taggable_id` and `taggable_type` columns. This modification disable duplicate tags for the same model on database level.
- [x] Add foreign keys to the `taggable_taggables` table.
- [x] Allow migrations to be published. You just need to change the `custom_migrations` flag to `true` in your `config/taggable.php` configuration file.
- [x] Rename primary key to follow laravel's convention.

@judgej It would be nice if you can review this PR.