### PR TITLE
Support for Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,15 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "illuminate/config": "^6.0",
-        "illuminate/database": "^6.0",
-        "illuminate/support": "^6.0"
+        "php": "^7.2.5",
+        "illuminate/config": "^6.0|^7.0",
+        "illuminate/database": "^6.0|^7.0",
+        "illuminate/support": "^6.0|^7.0"
     },
     "require-dev": {
         "limedeck/phpunit-detailed-printer": "^5.0",
-        "orchestra/database": "4.*",
-        "orchestra/testbench": "4.*",
+        "orchestra/database": "^4.0|^5.0",
+        "orchestra/testbench": "^4.0|^5.0",
         "phpunit/phpunit": "^8.0"
     },
     "autoload": {


### PR DESCRIPTION
This adds support for Laravel 6 or 7, as well as increases the PHP requirement to be minimally compatible with both versions.