### PR TITLE
remove set collation in column normalized for postgresql

### DIFF
--- a/resources/database/migrations/create_taggable_table.php.stub
+++ b/resources/database/migrations/create_taggable_table.php.stub
@@ -17,11 +17,24 @@ class CreateTaggableTable extends Migration
         $taggableTagsTable = config('taggable.tables.taggable_tags', 'taggable_tags');
         $taggableTaggablesTable = config('taggable.tables.taggable_taggables', 'taggable_taggables');
 
+        $charset = Schema::connection($connection)->getConnection()->getConfig('charset') ?? 'utf8mb4';
+        $driver = Schema::connection($connection)->getConnection()->getConfig('driver');
+
+        switch ($driver) {
+            case 'pgsql':
+                $collation = null;
+                break;
+            case 'sqlite':
+            case 'sqlsrv':
+            default:
+                $collation = $charset .'_bin';
+        }
+
         if (!Schema::connection($connection)->hasTable($taggableTagsTable)) {
-            Schema::connection($connection)->create($taggableTagsTable, static function(Blueprint $table) {
+            Schema::connection($connection)->create($taggableTagsTable, static function(Blueprint $table) use ($collation) {
                 $table->bigIncrements('tag_id');
                 $table->string('name');
-                $table->string('normalized')->unique();
+                $table->string('normalized')->unique()->collation($collation);
                 $table->timestamps();
 
                 $table->index('normalized');

--- a/resources/database/migrations/create_taggable_table.php.stub
+++ b/resources/database/migrations/create_taggable_table.php.stub
@@ -17,14 +17,11 @@ class CreateTaggableTable extends Migration
         $taggableTagsTable = config('taggable.tables.taggable_tags', 'taggable_tags');
         $taggableTaggablesTable = config('taggable.tables.taggable_taggables', 'taggable_taggables');
 
-        $charset = Schema::connection($connection)->getConnection()->getConfig('charset') ?? 'utf8mb4';
-        $collation = $charset .'_bin';
-
         if (!Schema::connection($connection)->hasTable($taggableTagsTable)) {
-            Schema::connection($connection)->create($taggableTagsTable, static function(Blueprint $table) use ($collation) {
+            Schema::connection($connection)->create($taggableTagsTable, static function(Blueprint $table) {
                 $table->bigIncrements('tag_id');
                 $table->string('name');
-                $table->string('normalized')->unique()->collation($collation);
+                $table->string('normalized')->unique();
                 $table->timestamps();
 
                 $table->index('normalized');


### PR DESCRIPTION
Then migration Migrating: 2021_03_30_111045_create_taggable_table gives an error when using the postgres with Laravel. Running php artisan migrate on a fresh installation gives the following error.

pull request for [issue](https://github.com/cviebrock/eloquent-taggable/issues/122)