### PR TITLE
remove alias for postgresql error

### DIFF
--- a/src/Services/TagService.php
+++ b/src/Services/TagService.php
@@ -293,11 +293,11 @@ class TagService
         $sql .= ' GROUP BY t.tag_id, t.name, t.normalized, t.created_at, t.updated_at';
 
         if ($minCount > 1) {
-            $sql .= ' HAVING taggable_count >= ?';
+            $sql .= ' HAVING COUNT(t.tag_id) >= ?';
             $bindings[] = $minCount;
         }
 
-        $sql .= ' ORDER BY taggable_count DESC';
+        $sql .= ' ORDER BY COUNT(t.tag_id) DESC';
 
         if ($limit) {
             $sql .= ' LIMIT ?';


### PR DESCRIPTION
in postgresql

`This is definitely illegal per the SQL spec: output column names are not
legal per spec in either GROUP BY or HAVING.  Postgres is lax about this
in GROUP BY (mainly for historical reasons), but not in HAVING --- and
even in GROUP BY, we only recognize an output column name if it is used
by itself, not as part of an expression.  So your HAVING clause would
lose even if we applied GROUP-BY-like rules to it.



If you can't restructure the query, I think you'll have to repeat the
sub-SELECT in the HAVING clause rather than refer to it via the field1
alias.  If you can restructure, consider`