### PR TITLE
Fix #140

### DIFF
--- a/src/Services/TagService.php
+++ b/src/Services/TagService.php
@@ -7,6 +7,7 @@ use Cviebrock\EloquentTaggable\Taggable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Collection as BaseCollection;
 
 
@@ -388,7 +389,7 @@ class TagService
             : new class extends Model {
                 use Taggable;
                 function getMorphClass() {
-                    return 'taggable-anonymous'; // any value will work, to keep Relation::enforceMorphMap() happy
+                    return Pivot::class;
                 }
             };
 

--- a/src/Services/TagService.php
+++ b/src/Services/TagService.php
@@ -218,7 +218,7 @@ class TagService
               LEFT JOIN {$tagTable} t ON tt.tag_id=t.tag_id
               WHERE tt.taggable_type = ?";
 
-        return $this->tagModel::fromQuery($sql, [$class]);
+        return $this->tagModel::fromQuery($sql, [$this->getClassTaggableType($class)]);
     }
 
     /**
@@ -288,7 +288,7 @@ class TagService
 
         if ($class) {
             $sql .= ' WHERE tt.taggable_type = ?';
-            $bindings[] = ($class instanceof Model) ? get_class($class) : $class;
+            $bindings[] = $this->getClassTaggableType($class);
         }
 
         // group by everything to handle strict and non-strict mode in MySQL
@@ -383,10 +383,23 @@ class TagService
     private function getQualifiedPivotTableName(string $class=null): string
     {
         /** @var \Cviebrock\EloquentTaggable\Taggable $instance */
-        $instance = $class ? new $class : new class extends Model { use Taggable; };
+        $instance = $class
+            ? new $class
+            : new class extends Model {
+                use Taggable;
+                function getMorphClass() {
+                    return 'taggable-anonymous'; // any value will work, to keep Relation::enforceMorphMap() happy
+                }
+            };
 
         return $instance->tags()->getConnection()->getTablePrefix() .
                 $instance->tags()->getTable();
     }
 
+    private function getClassTaggableType($class): string
+    {
+        return $class instanceof Model
+            ? $class->getMorphClass()
+            : (new $class)->getMorphClass();
+    }
 }


### PR DESCRIPTION
Use getMorphClass() instead of get_class to resolve the taggable_type. Add same to the anonymous class in getQualifiedPivotTableName().

Thank you for helping to make this package better!

Please make sure you've read [CONTRIBUTING.md](https://github.com/cviebrock/eloquent-sluggable/blob/master/CONTRIBUTING.md) 
before submitting your pull request, and that you have:

- [x] provided a rationale for your change (I try not to add features that are going to have a limited user-base)

See issue #140 for info.

- [x] used the [PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- [ ] added tests
No change to tests. I don't know how to change Relation::enforceMorphMap() dynamically.

- [ ] documented any change in behaviour (e.g. updated the `README.md`, etc.)
No change to behavior.

- [x] only submitted one pull request per feature
It's a small change.

