### PR TITLE
Correct renaming issue in TagService::renameTags()

### DIFF
--- a/src/Services/TagService.php
+++ b/src/Services/TagService.php
@@ -354,7 +354,7 @@ class TagService
 
         return $pivot
             ->where($relatedKeyName, $oldTag->getKey())
-            ->where($relatedMorphType, get_class($class))
+            ->where($relatedMorphType, $class->getMorphClass())
             ->update([
                 $relatedKeyName => $newTag->getKey(),
             ]);

--- a/tests/TagServiceTests.php
+++ b/tests/TagServiceTests.php
@@ -334,7 +334,7 @@ class TagServiceTests extends TestCase
         $morphModel->tag('Banana');
         $morphModel->tag('Cherry');
 
-        // Rename the tags just for one model class
+        // Rename the tags the morphModel class should have exactly 1 update
         $count = $this->service->renameTags('Apple', 'Apricot', $morphModel);
         $this->assertEquals(1, $count);
     }

--- a/tests/TagServiceTests.php
+++ b/tests/TagServiceTests.php
@@ -314,6 +314,32 @@ class TagServiceTests extends TestCase
     }
 
     /**
+     * Test renaming a tag.
+     */
+    public function testRenamingTagWithCustomMorphClass(): void
+    {
+        // Create a model with a custom morph class key
+        $morphModel = new class extends TestModel {
+            protected $attributes = [
+                'title' => 'testing morph model'
+            ];
+            public function getMorphClass()
+            {
+                return 'test-morph-model'; // can any custom key that is different from the class name
+            }
+        };
+        $morphModel->save();
+
+        $morphModel->tag('Apple');
+        $morphModel->tag('Banana');
+        $morphModel->tag('Cherry');
+
+        // Rename the tags just for one model class
+        $count = $this->service->renameTags('Apple', 'Apricot', $morphModel);
+        $this->assertEquals(1, $count);
+    }
+
+    /**
      * Test renaming a tag across all models.
      */
     public function testRenamingTagAllModels(): void

--- a/tests/TagServiceTests.php
+++ b/tests/TagServiceTests.php
@@ -314,7 +314,7 @@ class TagServiceTests extends TestCase
     }
 
     /**
-     * Test renaming a tag.
+     * Test renaming a tag with a custom morph class key.
      */
     public function testRenamingTagWithCustomMorphClass(): void
     {


### PR DESCRIPTION
Fixes issue #142 and adds a test for it.
