### PR TITLE
call values() on the sorted array to reset the keys

### DIFF
--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -466,7 +466,7 @@ trait Taggable
         /** @var \Illuminate\Database\Eloquent\Collection $tags */
         $tags = static::allTagModels();
 
-        return $tags->pluck('name')->sort()->all();
+        return $tags->pluck('name')->sort()->values()->all();
     }
 
     /**


### PR DESCRIPTION
without calling `values`, the returned array format in not consistent: sometimes a numbered array if returned (if sort happened to not change the order) or an assoc array (in case sort did actually move items around and kept their index).

![Screenshot 2024-06-06 at 14 28 31](https://github.com/cviebrock/eloquent-taggable/assets/8240619/c9c13aed-1711-4f42-998f-f434c4f88ea3)



Thank you for helping to make this package better!

Please make sure you've read [CONTRIBUTING.md](https://github.com/cviebrock/eloquent-sluggable/blob/master/CONTRIBUTING.md) 
before submitting your pull request, and that you have:

- [x] provided a rationale for your change (I try not to add features that are going to have a limited user-base)
- [x] used the [PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- [ ] added tests
- [x] documented any change in behaviour (e.g. updated the `README.md`, etc.)
- [x] only submitted one pull request per feature

**Thank you!**
