### PR TITLE
Fix php 8.4 deprecation warnings

### DIFF
--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -500,7 +500,7 @@ trait Taggable
      *
      * @return array
      */
-    public static function popularTags(int $limit = null, int $minCount = 1): array
+    public static function popularTags(?int $limit = null, int $minCount = 1): array
     {
         /** @var Collection $tags */
         $tags = app(TagService::class)->getPopularTags($limit, static::class, $minCount);
@@ -516,7 +516,7 @@ trait Taggable
      *
      * @return array
      */
-    public static function popularTagsNormalized(int $limit = null, int $minCount = 1): array
+    public static function popularTagsNormalized(?int $limit = null, int $minCount = 1): array
     {
         /** @var Collection $tags */
         $tags = app(TagService::class)->getPopularTags($limit, static::class, $minCount);


### PR DESCRIPTION
This fixes two warnings that pop up on php 8.4

- [x] provided a rationale for your change (I try not to add features that are going to have a limited user-base)
- [x] used the [PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- [ ] added tests
- [ ] documented any change in behaviour (e.g. updated the `README.md`, etc.)
- [x] only submitted one pull request per feature

